### PR TITLE
Work on a shallow copy of the original array of listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ module.exports = function asyncemit() {
   /**
    * Simple async helper utility.
    *
-   * @param {Array} stack The various of event listeners are async emitted.
-   * @api public
+   * @param {Array} stack The listeners for the specified event.
+   * @api private
    */
   (function each(stack) {
     if (!stack.length) return fn();
@@ -53,7 +53,7 @@ module.exports = function asyncemit() {
         each(stack);
       })
     );
-  })(listeners);
+  })(listeners.slice());
 
   return this;
 };

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ describe('asyncemit', function () {
     , EventEmitter = require('eventemitter3');
 
   beforeEach(function () {
-    ee = new EventEmitter;
+    ee = new EventEmitter();
     ee.asyncemit = asyncemit;
   });
 
@@ -19,7 +19,7 @@ describe('asyncemit', function () {
     assume(asyncemit).is.a('function');
   });
 
-  it('returns it self instead of a boolean', function () {
+  it('returns itself instead of a boolean', function () {
     assume(ee.asyncemit('foo', function () {})).equals(ee);
   });
 
@@ -122,6 +122,20 @@ describe('asyncemit', function () {
         assume(flow).equals('12');
         next();
       });
+    });
+  });
+
+  it('doesn\'t change the original array of listeners', function (next) {
+    ee.on('foo', function () {});
+    ee.on('foo', function () {});
+    ee.on('foo', function () {});
+
+    assume(ee.listeners('foo')).has.length(3);
+
+    ee.asyncemit('foo', 'bar', function (err) {
+      assume(err).is.undefined();
+      assume(ee.listeners('foo')).has.length(3);
+      next();
     });
   });
 });


### PR DESCRIPTION
If we call `shift()` directly on the array of listeners of the `EventEmitter` we remove listeners that should probably not be removed.
