### PR TITLE
Make it work with the latest version of eventemitter3

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function asyncemit() {
     , selfie = this
     , listeners;
 
-  listeners = (this._events || {})[event] || [];
+  listeners = (this._events || {})['~'+ event] || [];
   if (listeners && !Array.isArray(listeners)) {
     listeners = [ listeners ];
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/primus/asyncemit",
   "devDependencies": {
     "assume": "1.2.x",
-    "eventemitter3": "0.1.x",
+    "eventemitter3": "1.0.x",
     "istanbul": "0.3.x",
     "mocha": "2.2.x",
     "pre-commit": "1.0.x"


### PR DESCRIPTION
The event names in `eventemitter3@1.0.x` are prefixed with a `~`.
In order to retrieve the `listeners` we need to prefix the event name accordingly.

This is a breaking change as it requires `eventemitter3` to be updated.
