### PR TITLE
[major] Use the newly introduced `prefixed` property

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,20 @@
 'use strict';
 
+var prefix = require('eventemitter3').prefixed
+  , toString = Object.prototype.toString
+  , slice = Array.prototype.slice
+
+/**
+ * Get an accurate type description of whatever we receive.
+ *
+ * @param {Mixed} what What ever we receive
+ * @returns {String} Description of what ever it is.
+ * @api private
+ */
+function type(what) {
+  return toString.call(what).slice(8, -1).toLowerCase();
+}
+
 /**
  * Asynchronously emit an event.
  *
@@ -10,17 +25,17 @@
  * @api public
  */
 module.exports = function asyncemit() {
-  var args = Array.prototype.slice.call(arguments, 0)
+  var args = slice.call(arguments, 0)
     , event = args.shift()
     , async = args.length
     , fn = args.pop()
     , selfie = this
     , listeners;
 
-  listeners = (this._events || {})['~'+ event] || [];
-  if (listeners && !Array.isArray(listeners)) {
-    listeners = [ listeners ];
-  }
+  listeners = (this._events || {})[prefix ? '~'+ event : event];
+
+  if (!listeners) return fn(), this;
+  if (type(listeners) !== 'array') listeners = [ listeners ];
 
   /**
    * Simple async helper utility.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asyncemit",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Asynchronously emit event an event based on the arguments length.",
   "main": "index.js",
   "scripts": {
@@ -30,9 +30,11 @@
   "homepage": "https://github.com/primus/asyncemit",
   "devDependencies": {
     "assume": "1.2.x",
-    "eventemitter3": "1.0.x",
     "istanbul": "0.3.x",
     "mocha": "2.2.x",
     "pre-commit": "1.0.x"
+  },
+  "peerDependencies": {
+    "eventemitter3": ">=1.1.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -38,6 +38,10 @@ describe('asyncemit', function () {
     });
   });
 
+  it('calls the callback when no listeners are available', function (next) {
+    ee.asyncemit('foo', 'bar', next);
+  });
+
   it('works with full async emitters', function (next) {
     next = assume.plan(2, next);
     var foo;


### PR DESCRIPTION
Also made sure that this runs in ES3 environment by removing the Array.isArray requirement and ensured that the callback is called when there are no listeners. 

This branch assumes an unreleased version of the EventEmitter3. 
